### PR TITLE
Style updates to advisories page

### DIFF
--- a/frontend/_extensions/bcds/bcds-accordion.scss
+++ b/frontend/_extensions/bcds/bcds-accordion.scss
@@ -57,3 +57,11 @@ details.bcds-disclosure {
   border-radius: $layout-border-radius-medium $layout-border-radius-none $layout-border-radius-none $layout-border-radius-medium;
 }
 
+.accordian-btn {
+  border-radius: $layout-border-radius-medium;
+  border: 1px solid $surface-color-border-dark;
+  padding: $layout-padding-small $layout-padding-medium;
+  justify-content: center;
+  align-items: center;
+  margin-right: $layout-margin-medium;
+}

--- a/frontend/_extensions/bcds/bcds-accordion.scss
+++ b/frontend/_extensions/bcds/bcds-accordion.scss
@@ -41,6 +41,11 @@ details.bcds-disclosure {
     padding: $layout-padding-medium $layout-padding-large;
   }
 
+  .h1, .h2, .h3, .h4, .h5, .h6 {
+    margin-top: $layout-margin-none;
+    margin-bottom: $layout-margin-none;
+  }
+
   display: flex;
   flex-direction: column;
 

--- a/frontend/_extensions/bcds/bcds-cards.scss
+++ b/frontend/_extensions/bcds/bcds-cards.scss
@@ -82,8 +82,8 @@
   }
 
   .bcds-card-image {
-
-    height: 4rem;
+    max-width: 100%;
+    height: auto;
     display: block;
     padding: 0;
     //margin: $layout-margin-small 0 auto;

--- a/frontend/_extensions/bcds/bcds-cards.scss
+++ b/frontend/_extensions/bcds/bcds-cards.scss
@@ -70,6 +70,11 @@
   /* adjustable */
   width: $grid-body-width / 4;
 
+  &.wide {
+    /* full width when specified */
+    width: 100%;    
+  }
+
   @media only screen and (max-width: 575px) {
     /* full width looks better on small screens */
     width: 100%;

--- a/frontend/_extensions/bcds/bcds-cards.scss
+++ b/frontend/_extensions/bcds/bcds-cards.scss
@@ -2,9 +2,27 @@
 @import "variables.scss";
 @import "bcds.scss";
 
+.bcds-card-wrapper {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: $layout-margin-medium;
+  margin-bottom: $layout-margin-xlarge;
+
+  @media only screen and (max-width: 575px) {
+    /* only have one card per row for small screens*/
+    display: flex;
+    flex-direction: column;
+  }
+
+  .bcds-card {
+    /* don't set width on the card when in a wrapper, uses grid properties above */
+    width: 100%;    
+  }
+}
+
 .bcds-card {
 
-  padding: $layout-padding-small $layout-padding-small;
+  padding: $layout-padding-large $layout-padding-large;
   position: relative;
 
   .card-icon {
@@ -55,6 +73,10 @@
     display: inline-block;
   }
 
+  h5 {
+    line-height: $typography-line-heights-dense;
+  }
+
   h5::before {
     border: none;
   }
@@ -95,6 +117,12 @@
         content: '\f285';
       }
     }
+
+    p:last-child {
+      /* remove margin from the last paragraph around the link call to action */
+      margin-bottom: 0;
+    }
+
   }
 
 }

--- a/frontend/_extensions/bcds/bcds.lua
+++ b/frontend/_extensions/bcds/bcds.lua
@@ -44,12 +44,12 @@ return {
     if quarto.doc.is_format("html:js") then
       local markup = ""
 
-      markup = markup .. "<button class='btn' type='button' " ..
+      markup = markup .. "<button class='btn accordian-btn' type='button' " ..
           "onclick='BCDSExpandAll()'>" ..
           "Expand All" ..
           "</button>"
 
-      markup = markup .. "<button class='btn' type='button' " ..
+      markup = markup .. "<button class='btn accordian-btn' type='button' " ..
           "onclick='BCDSCollapseAll()'>" ..
           "Collapse All" ..
           "</button>"

--- a/frontend/_extensions/bcds/bcds.lua
+++ b/frontend/_extensions/bcds/bcds.lua
@@ -111,8 +111,9 @@ return {
       local variant = pandoc.utils.stringify(kwargs["variant"])
       local logo = pandoc.utils.stringify(kwargs["logo"])
       local useIcons = pandoc.utils.stringify(kwargs["useIcons"])
+      local width = pandoc.utils.stringify(kwargs["width"])
 
-      local markup = "<div class='bcds-card " .. variant .. "'>"
+      local markup = "<div class='bcds-card " .. variant .. " " .. width .. "'>"
 
       local icon_variant_map = {
         ['success'] = 'check-circle',

--- a/frontend/shortcode_demos.qmd
+++ b/frontend/shortcode_demos.qmd
@@ -157,8 +157,12 @@ untitled with logo card contents
 untitled danger card with logo card contents
 {{< card_end >}}
 
-{{< card_start>}}
-untitled card contents
+{{< card_start width="wide" >}}
+Wide version of a card, untitled
+{{< card_end >}}
+
+{{< card_start >}}
+Untitled card contents
 {{< card_end >}}
 
 ## Inline Alerts


### PR DESCRIPTION
- add outline for buttons
- adjust spacing for cards => NOTE: need to do some whitespace testing with source file
- and have images resize within cards
- add wide format for cards by adding width="wide" to {{< card_start width="wide" >}}
- fix margin for h2 accordions
- update the shortcode demos pages showing this

<img src="https://github.com/user-attachments/assets/55387392-937c-4805-b884-25f9054bf0a7" width="300px">
