### PR TITLE
task: Remove wildfire warnings file generation.

### DIFF
--- a/doc/WARNING_SELECTION_LOGIC.md
+++ b/doc/WARNING_SELECTION_LOGIC.md
@@ -1,0 +1,97 @@
+# Warning Selection Logic
+
+This document outlines how warnings are selected for inclusion in the Recent Warnings and Wildfire Smoke Warnings lists by the `construct-lists.py` script.
+
+## Overview
+
+The script processes input files from Quarto's project input files and categorizes them according to two main criteria:
+
+1. **Recent Warnings**: Warnings issued within the past 5 days (configurable via `RECENT_THRESHOLD_DAYS`)
+2. **Wildfire Smoke Warnings**: Specifically categorized wildfire smoke advisories with special handling
+
+## Selection Flowchart
+
+```mermaid
+flowchart TD
+    A[Start Processing File] --> B{Has YAML Header?}
+    B -->|No| Z[Skip File]
+    B -->|Yes| C[Extract Header Metadata]
+    
+    C --> F1{Is type 'wildfire_smoke'?}
+    F1 -->|Yes| D1{Has 'date' Metadata?}
+    F1 -->|No| D2{Has 'date' Metadata?}
+    
+    D1 -->|No| Z2[Skip Wildfire Processing]
+    D1 -->|Yes| E1[Calculate Age in Days]
+    
+    E1 --> G{Has ICE = 'issue'?}
+    
+    G -->|Yes| H[Set Threshold = 1 day]
+    G -->|No| I[Use Default Threshold: 5 days]
+    
+    H --> K{Age < Threshold?}
+    I --> K
+    
+    K -->|Yes| L[Add to WILDFIRE_SMOKE_WARNINGS]
+    K -->|No| Z3[Skip Wildfire List]
+    
+    D2 -->|No| Z4[Skip Recent Processing]
+    D2 -->|Yes| E2[Calculate Age in Days]
+    
+    E2 --> J{Age < RECENT_THRESHOLD_DAYS?}
+    
+    L --> R{Is type 'wildfire_smoke'?}
+    Z3 --> R
+    
+    R -->|Yes| S{Has ICE = 'issue'?}
+    R -->|No| J
+    
+    S -->|Yes| T{Age >= 1 day?}
+    S -->|No| J
+    
+    T -->|Yes| O[Skip Recent List]
+    T -->|No| J
+    
+    J -->|Yes| N[Add to RECENT_WARNINGS]
+    J -->|No| O
+```
+
+## Selection Logic Details
+
+### For Any Warning
+
+1. File is processed if it has a valid YAML header.
+2. Essential metadata is extracted (path, title, type, ice, date, location).
+3. Processing branches into two separate evaluation paths:
+   - Evaluation for Wildfire Smoke Warnings
+   - Evaluation for Recent Warnings
+
+### For Wildfire Smoke Warnings
+
+1. The code first checks if the file has `type: wildfire_smoke` metadata.
+2. If it does, the code then checks if the file has a `date` metadata field.
+3. If a date exists, age is calculated by comparing the warning's date to today's date (in BC timezone).
+4. Different thresholds apply:
+   - Default: Include if less than 5 days old (`RECENT_THRESHOLD_DAYS`)
+   - Special case: For warnings with `ice: issue`, include only if less than 1 day old
+5. If the age is less than the applicable threshold, the warning is added to the Wildfire Smoke Warnings list.
+
+### For Recent Warnings
+
+1. All files with a `date` metadata field are considered for the Recent Warnings list.
+2. Special handling for wildfire smoke warnings:
+   - If it's a wildfire smoke warning with `ice: issue` and is 1+ days old, it's explicitly excluded
+   - This is done to prevent older "issue" wildfire smoke warnings from appearing in the recent list
+3. Otherwise, any warning less than 5 days old (`RECENT_THRESHOLD_DAYS`) is included in the Recent Warnings list.
+
+## Technical Implementation
+
+The script:
+1. Reads input files from `QUARTO_PROJECT_INPUT_FILES` environment variable
+2. Extracts YAML headers using regex
+3. Applies the selection logic
+4. Outputs two YAML files:
+   - `_recent_warnings.yaml` for recent warnings
+   - `_wildfire.yaml` for wildfire smoke warnings
+
+These output files are then used in custom listings within the Quarto site.

--- a/doc/WARNING_SELECTION_LOGIC.md
+++ b/doc/WARNING_SELECTION_LOGIC.md
@@ -4,10 +4,23 @@ This document outlines how warnings are selected for inclusion on the front page
 
 ## Overview
 
-The script processes input files from Quarto's project input files and categorizes them according to two main criteria:
+The [script](https://github.com/bcgov/aqwarnings/blob/main/frontend/construct-lists.py) processes input files from Quarto's project input files and categorizes them according to two main criteria:
 
 1. **Recent Warnings**: Warnings issued within the past 5 days (configurable via `RECENT_THRESHOLD_DAYS`)
 2. **Wildfire Smoke Warnings**: Specifically categorized wildfire smoke advisories with special handling
+
+
+## Business Description
+
+The script:
+1. Reads input files from `QUARTO_PROJECT_INPUT_FILES` environment variable
+2. Extracts YAML headers using regex
+3. Applies the selection logic
+4. Outputs two YAML files:
+   - `_recent_warnings.yaml` for recent warnings
+   - `_wildfire.yaml` for wildfire smoke warnings
+
+These output files are then used in custom listings within the Quarto site.
 
 ## Selection Flowchart
 
@@ -82,16 +95,4 @@ flowchart TD
 2. Special handling for wildfire smoke warnings:
    - If it's a wildfire smoke warning with `ice: issue` and is 1+ days old, it's explicitly excluded
    - This is done to prevent older "issue" wildfire smoke warnings from appearing in the recent list
-3. Otherwise, any warning less than 5 days old (`RECENT_THRESHOLD_DAYS`) is added to `_recent_warnings.yaml`.
-
-## Technical Implementation
-
-The script:
-1. Reads input files from `QUARTO_PROJECT_INPUT_FILES` environment variable
-2. Extracts YAML headers using regex
-3. Applies the selection logic
-4. Outputs two YAML files:
-   - `_recent_warnings.yaml` for recent warnings
-   - `_wildfire.yaml` for wildfire smoke warnings
-
-These output files are then used in a [custom listing](https://github.com/bcgov/aqwarnings/blob/main/frontend/index.qmd#L4) on the front page of the Quarto web site.
+3. Otherwise, any warning less than 5 days old (`RECENT_THRESHOLD_DAYS`) is included in the Recent Warnings list.

--- a/doc/WARNING_SELECTION_LOGIC.md
+++ b/doc/WARNING_SELECTION_LOGIC.md
@@ -1,6 +1,6 @@
-# Warning Selection Logic
+# Front Page Selection Logic
 
-This document outlines how warnings are selected for inclusion in the Recent Warnings and Wildfire Smoke Warnings lists by the `construct-lists.py` script.
+This document outlines how warnings are selected for inclusion on the front page as part of site rendering.
 
 ## Overview
 
@@ -73,16 +73,16 @@ flowchart TD
 3. If a date exists, age is calculated by comparing the warning's date to today's date (in BC timezone).
 4. Different thresholds apply:
    - Default: Include if less than 5 days old (`RECENT_THRESHOLD_DAYS`)
-   - Special case: For warnings with `ice: issue`, include only if less than 1 day old
-5. If the age is less than the applicable threshold, the warning is added to the Wildfire Smoke Warnings list.
+   - Modifiers: For warnings with `ice: issue`, include only if less than 1 day old
+5. If the age is less than the applicable threshold, the warning is added to `_wildfire.yaml`.
 
 ### For Recent Warnings
 
-1. All files with a `date` metadata field are considered for the Recent Warnings list.
+1. All files with a `date` metadata field are considered.
 2. Special handling for wildfire smoke warnings:
    - If it's a wildfire smoke warning with `ice: issue` and is 1+ days old, it's explicitly excluded
    - This is done to prevent older "issue" wildfire smoke warnings from appearing in the recent list
-3. Otherwise, any warning less than 5 days old (`RECENT_THRESHOLD_DAYS`) is included in the Recent Warnings list.
+3. Otherwise, any warning less than 5 days old (`RECENT_THRESHOLD_DAYS`) is added to `_recent_warnings.yaml`.
 
 ## Technical Implementation
 
@@ -94,4 +94,4 @@ The script:
    - `_recent_warnings.yaml` for recent warnings
    - `_wildfire.yaml` for wildfire smoke warnings
 
-These output files are then used in custom listings within the Quarto site.
+These output files are then used in a [custom listing](https://github.com/bcgov/aqwarnings/blob/main/frontend/index.qmd#L4) on the front page of the Quarto web site.

--- a/frontend/construct-lists.py
+++ b/frontend/construct-lists.py
@@ -6,13 +6,11 @@ import re
 import yaml
 
 """
-This script generates two files as part of the pre-render process for quarto site generation
+This script generates a file as part of the pre-render process for quarto site generation
 
 RECENTS_FILE_NAME will contain a yaml list of files with a date attribute newer than RECENT_THRESHOLD_DAYS
 
-WILDFIRE_FILE_NAME will contain any with an `wildfire_smoke` meta attribute set to True
-
-These are then used in custom listings within the qmd markup
+This is then used in custom listings within the qmd markup
 """
 
 # editable -- consider posts less than RECENT_THRESHOLD_DAYS days old to be "recent"
@@ -20,14 +18,11 @@ These are then used in custom listings within the qmd markup
 RECENT_THRESHOLD_DAYS = 5
 RECENTS_FILE_NAME = '_recent_warnings.yaml'
 
-WILDFIRE_FILE_NAME = '_wildfire.yaml'
-
 # globals. do not modify.
-INPUT_FILES = os.getenv('QUARTO_PROJECT_INPUT_FILES').split("\n")
-HEADER_REGEX = re.compile('^---\n((.*\n)+)---\n', re.MULTILINE)
+INPUT_FILES = os.getenv("QUARTO_PROJECT_INPUT_FILES").split("\n")
+HEADER_REGEX = re.compile("^---\n((.*\n)+)---\n", re.MULTILINE)
 
 RECENT_WARNINGS = []
-WILDFIRE_SMOKE_WARNINGS = []
 
 
 def get_today_in_bc_timezone():
@@ -44,7 +39,7 @@ def process_input_files():
 
         print("processing input file: {file}".format(file=f))
 
-        with open(f, 'r') as file:
+        with open(f, "r") as file:
             contents = file.read()
             match = HEADER_REGEX.search(contents)
             if match:
@@ -53,38 +48,27 @@ def process_input_files():
 
                 # what goes in the generated yaml
                 entry_from_header = {
-                    'path': f,
-                    'title': parsed_header['title'],
-                    'type': parsed_header['type'] if 'type' in parsed_header else 'N/A',
-                    'ice': parsed_header['ice'] if 'ice' in parsed_header else 'N/A',
-                    'date': parsed_header['date'] if 'date' in parsed_header else None,
-                    'location': parsed_header['location'] if 'location' in parsed_header else None,
+                    "path": f,
+                    "title": parsed_header["title"],
+                    "type": parsed_header["type"] if "type" in parsed_header else "N/A",
+                    "ice": parsed_header["ice"] if "ice" in parsed_header else "N/A",
+                    "date": parsed_header["date"] if "date" in parsed_header else None,
+                    "location": parsed_header["location"]
+                    if "location" in parsed_header
+                    else None,
                 }
 
-                if 'type' in parsed_header and parsed_header['type'].lower() == 'wildfire_smoke':
-                    if 'date' in parsed_header:
-                        age = (get_today_in_bc_timezone() - parsed_header["date"]).days
-                        threshold = RECENT_THRESHOLD_DAYS
-
-                        if 'ice' in parsed_header and parsed_header['ice'].lower() == 'issue':
-                            threshold = 1  # Only 1 day for wildfire_smoke with ice = Issue
-
-                        if age < threshold:
-                            WILDFIRE_SMOKE_WARNINGS.append(entry_from_header)
-
-                # not mutually exclusive with wildfire_smoke
                 if 'date' in parsed_header:
                     skip = False
 
-                    # only add the most recent issued wildfire_smoke due to the differences in warning
-                    # comment this out to not have separate behaviour for wildfire_smoke
+                    # Special handling for wildfire_smoke warnings
                     if 'type' in parsed_header and parsed_header['type'].lower() == 'wildfire_smoke':
                         if 'ice' in parsed_header and parsed_header['ice'].lower() == 'issue':
                             age = (get_today_in_bc_timezone() - parsed_header["date"]).days
-                            threshold = 1  # Only 1 day for wildfire_smoke with ice = Issue
+                            threshold = 1
 
-                        if age >= threshold:
-                            skip = True
+                            if age >= threshold:
+                                skip = True
 
                     if not skip:
                         age = (get_today_in_bc_timezone() - parsed_header["date"]).days
@@ -98,6 +82,3 @@ process_input_files()
 
 with open(RECENTS_FILE_NAME, 'w') as output_file:
     yaml.safe_dump(RECENT_WARNINGS, output_file)
-
-with open(WILDFIRE_FILE_NAME, 'w') as output_file:
-    yaml.safe_dump(WILDFIRE_SMOKE_WARNINGS, output_file)


### PR DESCRIPTION
## Summary

This PR removes the separate processing and output file generation for wildfire smoke warnings. Instead, the system now consolidates all warning types into a single "recent warnings" list with special handling for wildfire smoke warnings.

## Changes

- Removed the generation of the _wildfire.yaml file and related logic
- Updated documentation in `WARNING_SELECTION_LOGIC.md` to reflect the simplified process
- Streamlined the warning selection logic to focus only on recent warnings
- Maintained special handling for wildfire smoke warnings with ice: issue (still excluded when ≥1 day old)
- Updated flowchart and documentation to match the new implementation

## Rationale

Consolidating to a single output file simplifies the warning management process while maintaining the required business logic for handling wildfire smoke warnings. This makes the system easier to maintain and reduces duplicate logic.

## Testing

The modified script has been tested and continues to:

- Apply special handling for wildfire smoke warnings
- Generate the _recent_warnings.yaml file with appropriate entries