### PR TITLE
feat: #79 Update Recent Warnings Logic

### DIFF
--- a/frontend/_aqw_listing.ejs
+++ b/frontend/_aqw_listing.ejs
@@ -13,7 +13,17 @@
         <% for (const item of items) { %>
             <tr>
                 <td><%= item.location %></td>
-                <td><a href="<%- item.path %>"><%= item.title %></a></td>
+                <td>
+                    <% if (item.type==="redirect" ) { %>
+                        <a href="<%= item.path %>" target="_blank" rel="noopener noreferrer">
+                            <%= item.title %> <span class="external-link">↗</span>
+                        </a>
+                    <% } else { %>
+                        <a href="<%- item.path %>">
+                            <%= item.title %>
+                        </a>
+                    <% } %>
+                </td>
                 <td><%= item.ice %></td>
                 <td><%= item.date %></td>
             </tr>

--- a/frontend/_aqw_listing.ejs
+++ b/frontend/_aqw_listing.ejs
@@ -14,7 +14,7 @@
             <tr>
                 <td><%= item.location %></td>
                 <td>
-                    <% if (item.type==="redirect" ) { %>
+                    <% if (item.type === "redirect" ) { %>
                         <a href="<%= item.path %>" target="_blank" rel="noopener noreferrer">
                             <%= item.title %> <span class="external-link">↗</span>
                         </a>

--- a/frontend/_recent_warnings.yaml
+++ b/frontend/_recent_warnings.yaml
@@ -1,0 +1,6 @@
+- date: 2025-07-01
+  ice: Issue
+  location: Northeast B.C.
+  path: warnings/2025-07-01_wildfire_smoke_issue.md
+  title: Air Quality Warning - Wildfire Smoke
+  type: wildfire_smoke

--- a/frontend/construct_lists.py
+++ b/frontend/construct_lists.py
@@ -2,7 +2,6 @@ import datetime
 import pytz
 import os
 import re
-import pathlib
 from typing import List, Dict, Any, Optional
 
 import yaml

--- a/frontend/construct_lists.py
+++ b/frontend/construct_lists.py
@@ -2,6 +2,7 @@ import datetime
 import pytz
 import os
 import re
+import pathlib
 from typing import List, Dict, Any, Optional
 
 import yaml
@@ -10,18 +11,21 @@ import yaml
 This script generates a file as part of the pre-render process for quarto site generation
 
 RECENTS_FILE_NAME will contain a yaml list of files with a date attribute newer than RECENT_THRESHOLD_DAYS
+Special handling is applied based on warning type and status.
 
 This is then used in custom listings within the qmd markup
 """
 
-# editable -- consider posts less than RECENT_THRESHOLD_DAYS days old to be "recent"
-# Hardcoded below to 1 day for smoky skies bulletins with ice = Issue metadata
-RECENT_THRESHOLD_DAYS = 5
+# editable -- consider "end" status warnings less than END_STATUS_THRESHOLD_DAYS days old to be "recent"
+END_STATUS_THRESHOLD_DAYS = 3
 RECENTS_FILE_NAME = '_recent_warnings.yaml'
+METRO_VANCOUVER_FILENAME = '_metro_vancouver.yml'
 
 # globals. do not modify.
 _quarto_input_files = os.getenv("QUARTO_PROJECT_INPUT_FILES")
 INPUT_FILES = _quarto_input_files.split("\n") if _quarto_input_files is not None else []
+INPUT_FILES.append(f'warnings/{METRO_VANCOUVER_FILENAME}')  # Ensure Metro Vancouver file is included
+
 HEADER_REGEX = re.compile("^---\n((.*\n)+)---\n", re.MULTILINE)
 
 
@@ -43,6 +47,15 @@ def extract_header_from_file(file_path: str) -> Optional[Dict[str, Any]]:
         Dictionary with metadata or None if no header found
     """
     try:
+        # Check if file exists
+        if not os.path.exists(file_path):
+            # Try with working directory prefix
+            alt_path = os.path.join(os.getcwd(), file_path)
+            if os.path.exists(alt_path):
+                file_path = alt_path
+            else:
+                return None
+                
         with open(file_path, "r") as file:
             contents = file.read()
             match = HEADER_REGEX.search(contents)
@@ -50,8 +63,11 @@ def extract_header_from_file(file_path: str) -> Optional[Dict[str, Any]]:
                 doc_preamble = match.group(1)
                 parsed_header = yaml.safe_load(doc_preamble)
                 # Prepare entry from header
+                # For redirect types, use the path from the YAML file if available
+                path_to_use = parsed_header.get("path") if parsed_header.get("type") == "redirect" else file_path
+                
                 entry_from_header = {
-                    "path": file_path,
+                    "path": path_to_use,
                     "title": parsed_header.get("title", "No Title"),
                     "type": parsed_header.get("type", "N/A"),
                     "ice": parsed_header.get("ice", "N/A"),
@@ -63,6 +79,30 @@ def extract_header_from_file(file_path: str) -> Optional[Dict[str, Any]]:
                     "entry": entry_from_header,
                     "raw_header": parsed_header
                 }
+            else:
+                # For YML files, try loading directly with yaml
+                if file_path.endswith('.yml'):
+                    try:
+                        parsed_header = yaml.safe_load(contents)
+                        if isinstance(parsed_header, dict):
+                            # For redirect types, use the path from the YAML file if available
+                            path_to_use = parsed_header.get("path") if parsed_header.get("type") == "redirect" else file_path
+                            
+                            entry_from_header = {
+                                "path": path_to_use,
+                                "title": parsed_header.get("title", "No Title"),
+                                "type": parsed_header.get("type", "N/A"),
+                                "ice": parsed_header.get("ice", "N/A"),
+                                "date": parsed_header.get("date"),
+                                "location": parsed_header.get("location"),
+                            }
+                            
+                            return {
+                                "entry": entry_from_header,
+                                "raw_header": parsed_header
+                            }
+                    except Exception as e:
+                        print(f"Error loading YAML directly: {e}")
     except Exception as e:
         print(f"Error processing file {file_path}: {e}")
     
@@ -72,51 +112,118 @@ def extract_header_from_file(file_path: str) -> Optional[Dict[str, Any]]:
 def select_recent_warnings(
     header_entries: List[Dict[str, Any]], 
     today_date=None,
-    recent_threshold_days: int = RECENT_THRESHOLD_DAYS
+    end_status_threshold_days: int = END_STATUS_THRESHOLD_DAYS
 ) -> List[Dict[str, Any]]:
     """
+    Select recent warnings based on type, community, and status.
+    
     Args:
         header_entries: List of dictionaries containing header metadata
         today_date: Optional date to use for comparison (for testing)
-        recent_threshold_days: Number of days to consider recent
+        end_status_threshold_days: Number of days to consider "end" status warnings as recent
         
     Returns:
         List of warnings that meet the criteria for "recent" status
 
-    Normally I don't like to include arguments specifically for testing, but the
-    freezegun testing library doesn't interact with timezones correctly, which
-    introduces false failures.
+    Selection logic:
+    1. Handle Metro Vancouver file specially
+    2. For wildfire smoke warnings: keep only the most recent
+    3. For other warnings: group by community and keep newest per community
+    4. For "end" status warnings: only show if less than end_status_threshold_days old
     """
     recent_warnings = []
     today = today_date or get_today_in_bc_timezone()
     
+    # Special handling for Metro Vancouver
+    metro_vancouver_entry = None
+    
+    # Group warnings by type and community
+    wildfire_warnings = []
+    community_warnings = {}  # {community: [warnings]}
     for header_data in header_entries:
         if not header_data:
             continue
             
         entry = header_data["entry"]
         parsed_header = header_data["raw_header"]
+        file_path = entry.get("path", "")
         
-        if not parsed_header.get("date"):
+        # Special handling for Metro Vancouver file
+        # Check either by filename or by type=redirect
+        if os.path.basename(file_path) == METRO_VANCOUVER_FILENAME or parsed_header.get("type") == "redirect":
+            metro_vancouver_entry = entry
+            # Add date if available or use today's date for age calculation
+            if parsed_header.get("date"):
+                entry["_date"] = parsed_header["date"]
+                entry["_age"] = (today - parsed_header["date"]).days
+            else:
+                entry["_date"] = today
+                entry["_age"] = 0
             continue
             
-        skip = False
+        if not parsed_header.get("date"):
+            continue
         
-        # Special handling for wildfire_smoke warnings with ice=issue
-        # As per WARNING_SELECTION_LOGIC.md flowchart, we exclude if age >= 1 day
-        if parsed_header.get("type", "").lower() == "wildfire_smoke":
-            if parsed_header.get("ice", "").lower() == "issue":
-                age = (today - parsed_header["date"]).days
-                threshold = 1
-                
-                # Skip if age is >= threshold (1+ days old)
-                if age >= threshold:
-                    skip = True
+        # Calculate age of the warning    
+        age = (today - parsed_header["date"]).days
         
-        if not skip:
-            age = (today - parsed_header["date"]).days
-            if age < recent_threshold_days:
-                recent_warnings.append(entry)
+        # Store the warning based on type
+        warning_type = parsed_header.get("type", "").lower()
+        location = parsed_header.get("location", "unknown")
+        
+        # Add age to the entry for sorting
+        entry["_age"] = age
+        entry["_date"] = parsed_header["date"]
+        
+        if warning_type == "wildfire_smoke":
+            wildfire_warnings.append(entry)
+        else:
+            if location not in community_warnings:
+                community_warnings[location] = []
+            community_warnings[location].append(entry)
+
+    # Process wildfire warnings - keep only the newest one
+    if wildfire_warnings:
+        # Sort by date in descending order (newest first), then by age in ascending order
+        newest_wildfire = sorted(wildfire_warnings, key=lambda w: (-w["_date"].toordinal(), w["_age"]))[0]
+        ice_status = newest_wildfire.get("ice", "")
+        
+        if ice_status.lower() == "end":
+            # Only include "end" status warnings if they're strictly less than threshold days old
+            if newest_wildfire["_age"] < end_status_threshold_days:
+                recent_warnings.append(newest_wildfire)
+        else:
+            recent_warnings.append(newest_wildfire)
+    
+    # Process community warnings - keep newest per community
+    for warnings in community_warnings.values():
+        if warnings:
+            # Sort by date in descending order (newest first), then by age in ascending order
+            newest_warning = sorted(warnings, key=lambda w: (-w["_date"].toordinal(), w["_age"]))[0]
+            ice_status = newest_warning.get("ice", "")
+            
+            if ice_status.lower() == "end":
+                # Only include "end" status warnings if they're strictly less than threshold days old
+                if newest_warning["_age"] < end_status_threshold_days:
+                    recent_warnings.append(newest_warning)
+            else:
+                recent_warnings.append(newest_warning)
+    
+    # Process Metro Vancouver entry if present, going directly to the "ice = End" check
+    if metro_vancouver_entry:
+        ice_status = metro_vancouver_entry.get("ice", "")
+        
+        if ice_status.lower() == "end":
+            # Only include "end" status warnings if they're strictly less than threshold days old
+            if metro_vancouver_entry["_age"] < end_status_threshold_days:
+                recent_warnings.append(metro_vancouver_entry)
+        else:
+            recent_warnings.append(metro_vancouver_entry)
+    
+    # Remove temporary fields used for sorting
+    for warning in recent_warnings:
+        warning.pop("_age", None)
+        warning.pop("_date", None)
     
     return recent_warnings
 
@@ -129,7 +236,6 @@ def process_input_files():
         if not file_path:
             continue  # Skip empty input lines
             
-        print(f"Processing input file: {file_path}")
         header_data = extract_header_from_file(file_path)
         if header_data:
             header_entries.append(header_data)
@@ -139,8 +245,6 @@ def process_input_files():
 
 def main():
     """Main function to run the script"""
-    print(yaml.safe_dump(INPUT_FILES))
-    
     # Extract headers from all input files
     header_entries = process_input_files()
     

--- a/frontend/test_construct_lists.py
+++ b/frontend/test_construct_lists.py
@@ -8,14 +8,14 @@ from construct_lists import select_recent_warnings, extract_header_from_file, ge
 
 
 class TestWarningSelectionLogic(unittest.TestCase):
-    def test_select_recent_warnings(self):
-        """Test the warning selection logic with mock data"""
+    def test_select_recent_warnings_basic_logic(self):
+        """Test the basic warning selection logic with mock data"""
         # Mock today's date as 2025-06-13
         mock_today = datetime.date(2025, 6, 13)
         
         # Create some test header entries
         mock_headers = [
-            # Same-day wildfire smoke issue (0 days old) - should be included
+            # Newest wildfire smoke warning - should be included
             {
                 "entry": {
                     "path": "/path/to/warning1.md",
@@ -33,7 +33,7 @@ class TestWarningSelectionLogic(unittest.TestCase):
                     "location": "Interior"
                 }
             },
-            # 1-day-old wildfire smoke issue - should be excluded due to special handling (age >= 1)
+            # Older wildfire smoke warning - should be excluded as only newest is kept
             {
                 "entry": {
                     "path": "/path/to/warning2.md",
@@ -51,7 +51,7 @@ class TestWarningSelectionLogic(unittest.TestCase):
                     "location": "Interior"
                 }
             },
-            # Recent heat warning (3 days old) - should be included
+            # Heat warning for Coast - should be included as newest for this community
             {
                 "entry": {
                     "path": "/path/to/warning3.md",
@@ -69,7 +69,7 @@ class TestWarningSelectionLogic(unittest.TestCase):
                     "location": "Coast"
                 }
             },
-            # Old warning (6 days old) - should be excluded due to age
+            # Air quality warning for North - should be included as newest for this community
             {
                 "entry": {
                     "path": "/path/to/warning4.md",
@@ -93,42 +93,349 @@ class TestWarningSelectionLogic(unittest.TestCase):
                     "path": "/path/to/warning5.md",
                     "title": "Generic Warning",
                     "type": "other",
-                    "ice": "issue",
+                    "ice": "Issue",
                     "date": None,
                     "location": "Province-wide"
                 },
                 "raw_header": {
                     "title": "Generic Warning",
                     "type": "other",
-                    "ice": "issue",
+                    "ice": "Issue",
                     "location": "Province-wide"
                 }
             }
         ]
         
-        # Test with default threshold (5 days)
+        # Test with default settings
         recent_warnings = select_recent_warnings(mock_headers, today_date=mock_today)
         
-        # We should have 2 warnings (recent wildfire smoke and heat warning)
-        self.assertEqual(len(recent_warnings), 2)
+        # We should have 3 warnings (newest wildfire + one for each community)
+        self.assertEqual(len(recent_warnings), 3)
         
         # Check that the right warnings were selected
         paths = [warning["path"] for warning in recent_warnings]
-        self.assertIn("/path/to/warning1.md", paths)  # Recent wildfire smoke
-        self.assertIn("/path/to/warning3.md", paths)  # Heat warning
+        self.assertIn("/path/to/warning1.md", paths)  # Newest wildfire smoke
+        self.assertIn("/path/to/warning3.md", paths)  # Heat warning for Coast
+        self.assertIn("/path/to/warning4.md", paths)  # Air quality for North
         
         # Check that excluded warnings are not present
-        self.assertNotIn("/path/to/warning2.md", paths)  # Old wildfire smoke
-        self.assertNotIn("/path/to/warning4.md", paths)  # Old air quality
+        self.assertNotIn("/path/to/warning2.md", paths)  # Older wildfire smoke
         self.assertNotIn("/path/to/warning5.md", paths)  # No date
+    
+    def test_end_status_warnings(self):
+        """Test handling of warnings with 'end' status"""
+        # Mock today's date as 2025-06-13
+        mock_today = datetime.date(2025, 6, 13)
         
-        # Test with custom threshold (2 days)
-        recent_warnings = select_recent_warnings(mock_headers, today_date=mock_today, recent_threshold_days=2)
+        mock_headers = [
+            # Recent "end" status warning (1 day old) - should be included
+            {
+                "entry": {
+                    "path": "/path/to/end_warning1.md",
+                    "title": "Ending Heat Warning",
+                    "type": "heat",
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 12),  # 1 day old
+                    "location": "Interior"
+                },
+                "raw_header": {
+                    "title": "Ending Heat Warning",
+                    "type": "heat",
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 12),
+                    "location": "Interior"
+                }
+            },
+            # Older "end" status warning (4 days old) - should be excluded
+            {
+                "entry": {
+                    "path": "/path/to/end_warning2.md",
+                    "title": "Ending Wildfire Smoke Warning",
+                    "type": "wildfire_smoke",
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 9),  # 4 days old
+                    "location": "Coast"
+                },
+                "raw_header": {
+                    "title": "Ending Wildfire Smoke Warning",
+                    "type": "wildfire_smoke",
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 9),
+                    "location": "Coast"
+                }
+            }
+        ]
         
-        # We should have only 1 warning now
+        recent_warnings = select_recent_warnings(mock_headers, today_date=mock_today)
+        
+        # Only the 1-day old "end" status warning should be included
         self.assertEqual(len(recent_warnings), 1)
-        self.assertEqual(recent_warnings[0]["path"], "/path/to/warning1.md")
+        self.assertEqual(recent_warnings[0]["path"], "/path/to/end_warning1.md")
+        
+        # Test with custom threshold (0 days) - no "end" status warnings should be included
+        recent_warnings = select_recent_warnings(
+            mock_headers, 
+            today_date=mock_today,
+            end_status_threshold_days=0
+        )
+        self.assertEqual(len(recent_warnings), 0)
+    
+    def test_metro_vancouver_handling(self):
+        """Test special handling for Metro Vancouver file"""
+        # Mock today's date as 2025-06-13
+        mock_today = datetime.date(2025, 6, 13)
+        
+        # Test case 1: Metro Vancouver without End status
+        mock_headers = [
+            # Metro Vancouver special file - should be included
+            {
+                "entry": {
+                    "path": "https://metrovancouver.org/air-quality",
+                    "title": "Metro Vancouver Air Quality",
+                    "type": "redirect",
+                    "ice": "Issue"
+                },
+                "raw_header": {
+                    "title": "Metro Vancouver Air Quality",
+                    "type": "redirect",
+                    "ice": "Issue",
+                    "path": "https://metrovancouver.org/air-quality"
+                }
+            },
+            # Regular warning
+            {
+                "entry": {
+                    "path": "/path/to/regular_warning.md",
+                    "title": "Regular Warning",
+                    "type": "heat",
+                    "date": datetime.date(2025, 6, 12),
+                    "location": "Interior",
+                    "ice": "Issue"
+                },
+                "raw_header": {
+                    "title": "Regular Warning",
+                    "type": "heat",
+                    "date": datetime.date(2025, 6, 12),
+                    "location": "Interior",
+                    "ice": "Issue"
+                }
+            }
+        ]
+        
+        recent_warnings = select_recent_warnings(mock_headers, today_date=mock_today)
+        
+        # Both warnings should be included
+        self.assertEqual(len(recent_warnings), 2)
+        paths = [warning["path"] for warning in recent_warnings]
+        self.assertIn("https://metrovancouver.org/air-quality", paths)
+        self.assertIn("/path/to/regular_warning.md", paths)
+        
+        # Test case 2: Metro Vancouver with End status but recent (within threshold)
+        mock_headers = [
+            {
+                "entry": {
+                    "path": "https://metrovancouver.org/air-quality",
+                    "title": "Metro Vancouver Air Quality",
+                    "type": "redirect",
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 12)  # 1 day old
+                },
+                "raw_header": {
+                    "title": "Metro Vancouver Air Quality",
+                    "type": "redirect",
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 12),
+                    "path": "https://metrovancouver.org/air-quality"
+                }
+            }
+        ]
+        
+        recent_warnings = select_recent_warnings(mock_headers, today_date=mock_today)
+        
+        # Metro Vancouver warning should be included (only 1 day old)
+        self.assertEqual(len(recent_warnings), 1)
+        self.assertEqual(recent_warnings[0]["path"], "https://metrovancouver.org/air-quality")
+        
+        # Test case 3: Metro Vancouver with End status and old (beyond threshold)
+        mock_headers = [
+            {
+                "entry": {
+                    "path": "https://metrovancouver.org/air-quality",
+                    "title": "Metro Vancouver Air Quality",
+                    "type": "redirect",
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 9)  # 4 days old
+                },
+                "raw_header": {
+                    "title": "Metro Vancouver Air Quality",
+                    "type": "redirect",
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 9),
+                    "path": "https://metrovancouver.org/air-quality"
+                }
+            }
+        ]
+        
+        recent_warnings = select_recent_warnings(mock_headers, today_date=mock_today)
+        
+        # Metro Vancouver warning should be excluded (4 days old with End status)
+        self.assertEqual(len(recent_warnings), 0)
 
+    def test_newest_per_community(self):
+        """Test that we only keep the newest warning per community"""
+        # Mock today's date as 2025-06-13
+        mock_today = datetime.date(2025, 6, 13)
+        
+        mock_headers = [
+            # Newest warning for Interior
+            {
+                "entry": {
+                    "path": "/path/to/interior_newest.md",
+                    "title": "Newest Interior Warning",
+                    "type": "heat",
+                    "date": datetime.date(2025, 6, 12),  # 1 day old
+                    "location": "Interior",
+                    "ice": "Issue"
+                },
+                "raw_header": {
+                    "title": "Newest Interior Warning",
+                    "type": "heat",
+                    "date": datetime.date(2025, 6, 12),
+                    "location": "Interior",
+                    "ice": "Issue"
+                }
+            },
+            # Older warning for Interior - should be excluded
+            {
+                "entry": {
+                    "path": "/path/to/interior_older.md",
+                    "title": "Older Interior Warning",
+                    "type": "heat",
+                    "date": datetime.date(2025, 6, 10),  # 3 days old
+                    "location": "Interior",
+                    "ice": "Issue"
+                },
+                "raw_header": {
+                    "title": "Older Interior Warning",
+                    "type": "heat",
+                    "date": datetime.date(2025, 6, 10),
+                    "location": "Interior",
+                    "ice": "Issue"
+                }
+            },
+            # Newest warning for Coast
+            {
+                "entry": {
+                    "path": "/path/to/coast_newest.md",
+                    "title": "Newest Coast Warning",
+                    "type": "air_quality",
+                    "date": datetime.date(2025, 6, 11),  # 2 days old
+                    "location": "Coast",
+                    "ice": "Issue"
+                },
+                "raw_header": {
+                    "title": "Newest Coast Warning",
+                    "type": "air_quality",
+                    "date": datetime.date(2025, 6, 11),
+                    "location": "Coast",
+                    "ice": "Issue"
+                }
+            },
+            # Older warning for Coast - should be excluded
+            {
+                "entry": {
+                    "path": "/path/to/coast_older.md",
+                    "title": "Older Coast Warning",
+                    "type": "air_quality",
+                    "date": datetime.date(2025, 6, 9),  # 4 days old
+                    "location": "Coast",
+                    "ice": "Issue"
+                },
+                "raw_header": {
+                    "title": "Older Coast Warning",
+                    "type": "air_quality",
+                    "date": datetime.date(2025, 6, 9),
+                    "location": "Coast",
+                    "ice": "Issue"
+                }
+            }
+        ]
+        
+        recent_warnings = select_recent_warnings(mock_headers, today_date=mock_today)
+        
+        # We should have exactly 2 warnings - the newest for each community
+        self.assertEqual(len(recent_warnings), 2)
+        
+        paths = [warning["path"] for warning in recent_warnings]
+        self.assertIn("/path/to/interior_newest.md", paths)
+        self.assertIn("/path/to/coast_newest.md", paths)
+        
+        # Check that older warnings are not included
+        self.assertNotIn("/path/to/interior_older.md", paths)
+        self.assertNotIn("/path/to/coast_older.md", paths)
+
+    def test_wildfire_warning_selection(self):
+        """Test that only the most recent wildfire smoke warning is kept, regardless of location"""
+        # Mock today's date as 2025-06-13
+        mock_today = datetime.date(2025, 6, 13)
+        
+        mock_headers = [
+            # Newest wildfire warning
+            {
+                "entry": {
+                    "path": "/path/to/wildfire_newest.md",
+                    "title": "Newest Wildfire Warning",
+                    "type": "wildfire_smoke",
+                    "date": datetime.date(2025, 6, 13),  # Today
+                    "location": "Interior"
+                },
+                "raw_header": {
+                    "title": "Newest Wildfire Warning",
+                    "type": "wildfire_smoke",
+                    "date": datetime.date(2025, 6, 13),
+                    "location": "Interior"
+                }
+            },
+            # Older wildfire warning from same location - should be excluded
+            {
+                "entry": {
+                    "path": "/path/to/wildfire_older_same_loc.md",
+                    "title": "Older Wildfire Warning",
+                    "type": "wildfire_smoke",
+                    "date": datetime.date(2025, 6, 12),  # 1 day old
+                    "location": "Interior"
+                },
+                "raw_header": {
+                    "title": "Older Wildfire Warning",
+                    "type": "wildfire_smoke",
+                    "date": datetime.date(2025, 6, 12),
+                    "location": "Interior"
+                }
+            },
+            # Older wildfire warning from different location - should still be excluded
+            {
+                "entry": {
+                    "path": "/path/to/wildfire_older_diff_loc.md",
+                    "title": "Older Wildfire Warning Different Location",
+                    "type": "wildfire_smoke",
+                    "date": datetime.date(2025, 6, 11),  # 2 days old
+                    "location": "Coast"
+                },
+                "raw_header": {
+                    "title": "Older Wildfire Warning Different Location",
+                    "type": "wildfire_smoke",
+                    "date": datetime.date(2025, 6, 11),
+                    "location": "Coast"
+                }
+            }
+        ]
+        
+        recent_warnings = select_recent_warnings(mock_headers, today_date=mock_today)
+        
+        # We should have exactly 1 warning - only the newest wildfire warning
+        self.assertEqual(len(recent_warnings), 1)
+        self.assertEqual(recent_warnings[0]["path"], "/path/to/wildfire_newest.md")
+        
 
 class TestTimezoneHandling(unittest.TestCase):
     """Test class for timezone handling in warning selection"""
@@ -152,125 +459,113 @@ class TestTimezoneHandling(unittest.TestCase):
             self.assertEqual(bc_today, expected_date)
     
     def test_warning_expiry_at_bc_midnight(self):
-        """Test that warnings expire at midnight BC time, not UTC"""
-        # Create a test warning with date 2025-06-09 (4 days before our test date)
+        """Test that end status warnings expire at the right time"""
+        # Create a test warning with date 2025-06-10 (3 days before our test date)
         mock_headers = [
             {
                 "entry": {
                     "path": "/path/to/expiring_warning.md",
                     "title": "Expiring Warning",
                     "type": "heat",
-                    "ice": "issue",
-                    "date": datetime.date(2025, 6, 9),  # 4 days before 2025-06-13
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 10),  # 3 days before 2025-06-13
                     "location": "Interior"
                 },
                 "raw_header": {
                     "title": "Expiring Warning",
                     "type": "heat",
-                    "ice": "issue", 
-                    "date": datetime.date(2025, 6, 9),
+                    "ice": "End", 
+                    "date": datetime.date(2025, 6, 10),
                     "location": "Interior"
                 }
             }
         ]
         
-        # Scenario 1: Test with BC time on June 13 (4 days since June 9)
-        # The warning should still be included (not expired) as age is less than threshold
-        bc_time_day4 = datetime.date(2025, 6, 13)
-        warnings = select_recent_warnings(mock_headers, today_date=bc_time_day4)
-        self.assertEqual(len(warnings), 1, "Warning should be included when age < threshold")
+        # Scenario 1: Test with BC time on June 13 (3 days since June 10)
+        # The warning should be excluded as age = threshold
+        bc_time_day3 = datetime.date(2025, 6, 13)
+        warnings = select_recent_warnings(mock_headers, today_date=bc_time_day3)
+        self.assertEqual(len(warnings), 0, "Warning should be excluded when age = threshold")
         
-        # Scenario 2: Test with BC time on June 14 (5 days since June 9)
-        # The warning should be excluded (expired) as age equals threshold
-        bc_time_day5 = datetime.date(2025, 6, 14)
-        warnings = select_recent_warnings(mock_headers, today_date=bc_time_day5)
-        self.assertEqual(len(warnings), 0, "Warning should expire when age = threshold")
+        # Scenario 2: Test with BC time on June 12 (2 days since June 10)
+        # The warning should be included as age < threshold
+        bc_time_day2 = datetime.date(2025, 6, 12)
+        warnings = select_recent_warnings(mock_headers, today_date=bc_time_day2)
+        self.assertEqual(len(warnings), 1, "Warning should be included when age < threshold")
     
     def test_timezone_edge_case(self):
         """Test warning selection using real timezone handling with mocked time"""
-        # Create a warning that's 4 days old (just under the threshold)
+        # Create a warning that's the newest for its community
         mock_headers = [
             {
                 "entry": {
                     "path": "/path/to/edge_case_warning.md",
                     "title": "Edge Case Warning",
                     "type": "air_quality", 
-                    "ice": "issue",
-                    "date": datetime.date(2025, 6, 9),  # 4 days before 2025-06-13
-                    "location": "Coast"
+                    "date": datetime.date(2025, 6, 9),  # From Coast community
+                    "location": "Coast",
+                    "ice": "Issue"
                 },
                 "raw_header": {
                     "title": "Edge Case Warning",
                     "type": "air_quality",
-                    "ice": "issue",
                     "date": datetime.date(2025, 6, 9),
-                    "location": "Coast" 
+                    "location": "Coast",
+                    "ice": "Issue"
                 }
             }
         ]
         
-        # Test 1: When BC date is 2025-06-13, warning is 4 days old and should be included
+        # Test with BC date - warning should be included as it's the newest for its community
         with patch.object(construct_lists, 'get_today_in_bc_timezone', return_value=datetime.date(2025, 6, 13)):
             warnings = select_recent_warnings(mock_headers)  # No today_date, will use mocked function
-            self.assertEqual(len(warnings), 1, "Warning should be included when age < threshold")
-        
-        # Test 2: When BC date is 2025-06-14, warning is 5 days old and should be excluded
-        with patch.object(construct_lists, 'get_today_in_bc_timezone', return_value=datetime.date(2025, 6, 14)):
-            warnings = select_recent_warnings(mock_headers)  # No today_date, will use mocked function
-            self.assertEqual(len(warnings), 0, "Warning should expire when age = threshold")
+            self.assertEqual(len(warnings), 1, "Warning should be included as newest for community")
     
     def test_utc_vs_bc_timezone_bug(self):
-        """Test specifically for the timezone bug scenario - warnings disappearing too early"""
-        # Create a warning dated June 9, 2025
+        """Test specifically for the timezone bug scenario - warnings using correct timezone"""
+        # Create a warning with status=end that's 3 days old
         mock_headers = [
             {
                 "entry": {
                     "path": "/path/to/timezone_bug_warning.md",
                     "title": "Timezone Bug Test Warning",
                     "type": "heat",
-                    "ice": "issue",
-                    "date": datetime.date(2025, 6, 9),
+                    "ice": "End",
+                    "date": datetime.date(2025, 6, 10),  # 3 days before June 13
                     "location": "Interior"
                 },
                 "raw_header": {
                     "title": "Timezone Bug Test Warning",
                     "type": "heat",
-                    "ice": "issue", 
-                    "date": datetime.date(2025, 6, 9),
+                    "ice": "End", 
+                    "date": datetime.date(2025, 6, 10),
                     "location": "Interior"
                 }
             }
         ]
         
-        # Scenario: It's still June 13 in BC (late evening), but already June 14 in UTC
-        # We want to ensure that warnings don't expire prematurely due to UTC time
+        # Scenario: It's still June 12 in BC (late evening), but already June 13 in UTC
+        # We want to ensure that we're using BC timezone for date calculations
         
-        # Mock the datetime to return a fixed UTC time (June 14, 2025 05:00 AM UTC)
-        # This corresponds to June 13, 2025 10:00 PM in BC (UTC-7)
-        mock_utc_datetime = datetime.datetime(2025, 6, 14, 5, 0, 0, tzinfo=pytz.UTC)
+        # Mock the datetime to return a fixed UTC time (June 13, 2025 05:00 AM UTC)
+        # This corresponds to June 12, 2025 10:00 PM in BC (UTC-7)
+        mock_utc_datetime = datetime.datetime(2025, 6, 13, 5, 0, 0, tzinfo=pytz.UTC)
         
-        # This test demonstrates the bug fix:
-        # If we use UTC time directly (June 14), the warning would incorrectly expire
-        # But using BC timezone (June 13), the warning should still be included
-        
-        # Step 1: Without timezone fixing (simulating the bug)
-        utc_date = mock_utc_datetime.date()  # This would be June 14 in UTC
-        warnings_with_utc = select_recent_warnings(mock_headers, today_date=utc_date)
-        self.assertEqual(len(warnings_with_utc), 0, "Using UTC time directly would incorrectly expire the warning")
-        
-        # Step 2: With timezone fixing via get_today_in_bc_timezone
+        # Step 1: Using BC timezone via get_today_in_bc_timezone
         with patch('datetime.datetime') as mock_datetime:
             mock_datetime.now.return_value = mock_utc_datetime
             mock_datetime.side_effect = lambda *args, **kw: datetime.datetime(*args, **kw)
             
             # Call the actual function we're testing
             bc_today = get_today_in_bc_timezone()
-            warnings_with_bc_timezone = select_recent_warnings(mock_headers, today_date=bc_today)
+            warnings = select_recent_warnings(mock_headers, today_date=bc_today)
             
-            self.assertEqual(len(warnings_with_bc_timezone), 1, 
-                           "Using BC timezone keeps warning active until BC midnight")
-            self.assertEqual(bc_today, datetime.date(2025, 6, 13),
-                           "BC date should be June 13 even when UTC is June 14")
+            self.assertEqual(bc_today, datetime.date(2025, 6, 12),
+                           "BC date should be June 12 even when UTC is June 13")
+            
+            # With BC date of June 12, the warning is 2 days old and should be included (age < threshold)
+            self.assertEqual(len(warnings), 1, 
+                          "End status warning should be included when age < threshold in BC timezone")
 
 
 if __name__ == "__main__":

--- a/frontend/warnings/_metro_vancouver.yml
+++ b/frontend/warnings/_metro_vancouver.yml
@@ -1,0 +1,6 @@
+title: Test Air Quality Advisory
+type: redirect
+date: 2025-01-01
+ice: "End"
+location: "Metro Vancouver"
+path: "https://metrovancouver.org/services/air-quality-climate-action/air-quality-data-and-advisories"


### PR DESCRIPTION
## Overview
This PR implements a significant update to the warning selection logic for the front page, as specified in issue #79. The changes include special handling for Metro Vancouver warnings, grouping warnings by community, and ensuring only the most recent warnings are displayed.

## Key Changes

### New Selection Logic
- **Special Handling for Metro Vancouver**: Added support for a special `_metro_vancouver.yml` file that redirects users to Vancouver's air quality website
- **Type-Based Selection**:
  - For wildfire smoke warnings: Only the most recent warning is shown, regardless of location
  - For non-wildfire warnings: Warnings are grouped by community, and only the newest warning for each community is shown
- **End Status Handling**: Warnings with status "End" are only shown for 3 days after issuance

### Code Improvements
- Added support for pure YAML files (without frontmatter delimiters)
- Improved URL handling for redirect-type warnings
- Added external link indicator for redirect links
- Enhanced test coverage with specific tests for each aspect of the new logic

### Documentation
- Updated the selection logic flowchart to accurately reflect the new implementation
- Added detailed descriptions of the new warning selection process
- Clarified handling of different warning types and statuses

## Testing
- Comprehensive test suite verifies all aspects of the new logic:
  - Basic warning selection
  - End status handling
  - Metro Vancouver special file handling
  - Community-based warning grouping
  - Wildfire warning selection
  - Timezone handling

## Screenshots
_[Screenshots of the new warning list would be added here]_

## Related Issues