### PR TITLE
update metro_vancouver.yml

### DIFF
--- a/frontend/warnings/_metro_vancouver.yml
+++ b/frontend/warnings/_metro_vancouver.yml
@@ -1,6 +1,6 @@
 title: Air Quality Warning
 type: redirect
 date: 2025-09-07
-ice: "Ended"
+ice: "End"
 location: "Eastern Fraser Valley"
 path: "https://metrovancouver.org/services/air-quality-climate-action/air-quality-data-and-advisories"


### PR DESCRIPTION
last warning issued by Metro Vancouver ended on Sept 7, 2025 but is still retained in the table on the landing page. Edited parameter: ice from "ended" to "end" to ensure proper script handling. Warning should now no longer be displayed in the table.