### PR TITLE
feat: Add automatic title generation and mandatory action column

### DIFF
--- a/doc/WARNING_DISPLAY_LOGIC.md
+++ b/doc/WARNING_DISPLAY_LOGIC.md
@@ -1,0 +1,74 @@
+# Warning Display Logic
+
+For display, automatic titling, and automatic mandatory action generation on the
+recent warnings list, the following minimal properties must be present in the
+YAML header or YAML file for the warning:
+
+```yaml
+date: ISO8601 date
+ice: string - "ISSUE", "CONTINUE", or "END"
+location: string
+type: string - "redirect", "wildfire_smoke", or "local_emissions"
+```
+
+In addition, the following properties are optional:
+
+```yaml
+path: string - Required only if the type is "redirect".
+overrideTitle: - boolean - If true, use the provided title property
+title: string - Required only if overrideTitle is present and set to true.
+bylaw: boolean - If present and true, Mandatory action will be "Yes". If present and false Mandatory Action will be "No"
+params:
+    burnRestrictions: integer - if present and greater than 0, Mandatory Action will be "Yes". Takes precedence over bylaw property.
+    pollutant: string - Required only if the type is "local_emissions". "PM25", "O3", "PM10", or "PM25 & PM10"
+```
+
+The following locations will have "Mandatory Action" set to "Yes" unless
+overridden by `bylaw: false`:
+
+- Burns Lake
+- Duncan
+- Houston
+- Prince George
+- Smithers
+- Valemount
+
+## Selecting the Title
+
+```mermaid
+flowchart TD;
+    A[Start] --> B{Is the &quot;overrideTitle&quot; property present?};
+    B -- Yes --> C[Set title to provided title property];
+    B -- No --> D{Is the type property &quot;redirect&quot;?};
+    D -- Yes --> E[Set title to &quot;Air Quality Warning&quot;];
+    D -- NO --> F{Is the type &quot;wildfire_smoke&quot;?};
+    F -- YES --> G[Set title to &quot;Wildfire Smoke&quot;];
+    F -- NO --> H{Is the type &quot;local_emissions&quot;?};
+    H -- NO --> I[Set title to &quot;N/A&quot;];
+    H -- YES --> J{Is the &quot;pollutant&quot; property present?};
+    J -- NO --> I;
+    J -- YES --> K{Is the pollutant &quot;PM25&quot;?};
+    K -- YES --> L[Set title to &quot;Fine particulate matter&quot;];
+    K -- NO --> M{Is the pollutant &quot;O3&quot;};
+    M -- YES --> N[Set title to &quot;Ground level ozone&quot;];
+    M -- NO --> O{Is the pollutant &quot;PM10&quot;?};
+    O -- YES --> P[Set title to &quot;Dust&quot;];
+    O -- NO --> Q{Is the pollutant &quot;PM25 & PM10&quot;?};
+    Q -- NO --> I;
+    Q -- YES --> R[Set title to &quot;Fine particulate matter and Dust&quot;];
+```
+
+## Selecting Mandatory Action
+
+```mermaid
+flowchart TD;
+    A[START] --> B{Is &quot;burnRestrictions&quot; present and greater than 0?};
+    B -- YES --> C[Set Mandatory Action to &quot;Yes&quot;];
+    B -- NO --> D{Is &quot;bylaw&quot; Present?};
+    D -- NO --> E{Is &quot;location&quot; in the predefined list?};
+    E -- YES --> C
+    E -- NO --> F[Set Mandatory Action to &quot;No&quot;]
+    D -- YES --> G{Is &quot;bylaw&quot; set to true?}
+    G -- YES --> C
+    G -- NO --> F
+```

--- a/frontend/_aqw_listing.ejs
+++ b/frontend/_aqw_listing.ejs
@@ -5,6 +5,7 @@
         <tr>
             <td>Location</td>
             <td>Warning Type</td>
+            <td>Mandatory Action</td>
             <td>Status</td>
             <td>Date</td>
         </tr>
@@ -16,7 +17,7 @@
                 <td>
                     <% if (item.type === "redirect" ) { %>
                         <a href="<%= item.path %>" target="_blank" rel="noopener noreferrer">
-                            <%= item.title %> <span class="external-link">↗</span>
+                            <%= item.title %><span class="external-link">&nbsp;&nbsp;&nbsp;↗</span>
                         </a>
                     <% } else { %>
                         <a href="<%- item.path %>">
@@ -24,7 +25,8 @@
                         </a>
                     <% } %>
                 </td>
-                <td><%= item.ice %></td>
+                <td><%= item.mandatoryAction %></td>
+                <td><%= item.status %></td>
                 <td><%= item.date %></td>
             </tr>
         <% } %>


### PR DESCRIPTION
This implements two new features for the recent air quality warnings page:

- There is now a Mandatory Action column expected to be either "Yes" or "No". The system will attempt to automatically determine this value.
- The system will now attempt to automatically determine the Title value that is displayed in the Warning Type column.

I have documented the feature here: https://github.com/bcgov/aqwarnings/blob/d80c726e3fe1aa2469bdfb2f5fa19bf40583ffc5/doc/WARNING_DISPLAY_LOGIC.md

I made some small changes to what we discussed:

- `bylaw` is not necessary as I've included the list of locations as was originally intended. However, the `bylaw` property, if present, will override "Mandatory Action" behaviour (except burn restrictions, which takes precedence). This is a backstop in case bylaws change and someone isn't immediately able to edit the list of locations currently affected by bylaw.
- `overrideTitle` is optional. This will allow you to bypass the automatically generated title and provide one of your own. This is a backstop in case a scenario comes out of left field and you need to put something we didn't think about in that column.
- I needed to add some special handling for the Metro Vancouver redirect.

This means that a minimal YAML header for a Wildfire Smoke warning is now:

```yaml
date: 2025-12-12
ice: ISSUE
location: Vernon
type: wildfire_smoke
```

Hopefully this will save everyone some typing :)