### PR TITLE
Update footer year and remove margin spacing

### DIFF
--- a/frontend/_extensions/bcds/_extension.yaml
+++ b/frontend/_extensions/bcds/_extension.yaml
@@ -30,7 +30,7 @@ contributes:
           <div class='bcds-footer--container-content'>
           <div class='bcds-footer--logo-links horizontal'>
           <div class='bcds-footer--logo'>
-          <img class='navbar-brand-logo' src='/_extensions/bcds/assets/BCID_H_rgb_pos.svg'/>
+          <img class='navbar-brand-logo' src='/_extensions/bcds/assets/BCID_H_rgb_pos.svg' alt='Government of B.C.' />
           <p>We can help in over 220 languages and through other accessible options.<!-- -->
           <a href='https://www2.gov.bc.ca/gov/content?id=6A77C17D0CCB48F897F8598CCC019111'>Call, email or text
           us</a>, or<!-- --> <a
@@ -40,14 +40,12 @@ contributes:
           <figcaption class='bcds-footer--links-title'>More Info</figcaption>
           <ul>
           <li><a href='https://www2.gov.bc.ca/gov/content/home'>Home</a></li>
-          <li><a href='https://www2.gov.bc.ca/gov/content?id=3C4F47288DFB454987435AB5EFEFBB7F'>About gov.bc.ca</a>
-          </li>
-          <li><a href='https://www2.gov.bc.ca/gov/content?id=79F93E018712422FBC8E674A67A70535'>Disclaimer</a></li>
-          <li><a href='https://www2.gov.bc.ca/gov/content?id=9E890E16955E4FF4BF3B0E07B4722932'>Privacy</a></li>
-          <li><a href='https://www2.gov.bc.ca/gov/content?id=E08E79740F9C41B9B0C484685CC5E412'>Accessibility</a>
-          </li>
+          <li><a href='https://www2.gov.bc.ca/gov/content?id=E08E79740F9C41B9B0C484685CC5E412'>Accessibility</a></li>
+          <li><a href='https://www2.gov.bc.ca/gov/content?id=3C4F47288DFB454987435AB5EFEFBB7F'>About gov.bc.ca</a></li>
           <li><a href='https://www2.gov.bc.ca/gov/content?id=1AAACC9C65754E4D89A118B875E0FBDA'>Copyright</a></li>
+          <li><a href='https://www2.gov.bc.ca/gov/content?id=79F93E018712422FBC8E674A67A70535'>Disclaimer</a></li>
           <li><a href='https://www2.gov.bc.ca/gov/content?id=6A77C17D0CCB48F897F8598CCC019111'>Contact us</a></li>
+          <li><a href='https://www2.gov.bc.ca/gov/content?id=9E890E16955E4FF4BF3B0E07B4722932'>Privacy</a></li>
           </ul>
           </figure>
           </div>

--- a/frontend/_extensions/bcds/_extension.yaml
+++ b/frontend/_extensions/bcds/_extension.yaml
@@ -52,7 +52,7 @@ contributes:
           </figure>
           </div>
           <hr/>
-          <p class='bcds-footer--copyright'>© 2025 Government of British Columbia.</p></div>
+          <p class='bcds-footer--copyright'>© 2026 Government of British Columbia.</p></div>
           </div>
           </footer>
       resources:

--- a/frontend/_extensions/bcds/_extension.yaml
+++ b/frontend/_extensions/bcds/_extension.yaml
@@ -50,7 +50,7 @@ contributes:
           </figure>
           </div>
           <hr/>
-          <p class='bcds-footer--copyright'>© 2026 Government of British Columbia.</p></div>
+          <p class='bcds-footer--copyright'>© 2026 Government of British Columbia</p></div>
           </div>
           </footer>
       resources:

--- a/frontend/_extensions/bcds/bcds-accordion.scss
+++ b/frontend/_extensions/bcds/bcds-accordion.scss
@@ -12,6 +12,7 @@ details.bcds-disclosure {
     font-weight: $typography-font-weights-bold;
     padding: $layout-padding-medium $layout-padding-large;
     color: $typography-color-primary;
+    border-radius: $layout-border-radius-medium $layout-border-radius-medium $layout-border-radius-small $layout-border-radius-small;
 
     position: relative;
   }
@@ -54,7 +55,7 @@ details.bcds-disclosure {
   padding: 0;
   box-sizing: border-box;
   border: $layout-border-width-small solid $surface-color-border-default;
-  border-radius: $layout-border-radius-medium $layout-border-radius-none $layout-border-radius-none $layout-border-radius-medium;
+  border-radius: $layout-border-radius-medium $layout-border-radius-medium $layout-border-radius-medium $layout-border-radius-medium;
 }
 
 .accordian-btn {

--- a/frontend/_extensions/bcds/bcds-footer.scss
+++ b/frontend/_extensions/bcds/bcds-footer.scss
@@ -122,6 +122,7 @@
 > .bcds-footer--logo-links
 > .bcds-footer--logo
 > p {
+  color: $typography-color-secondary;
   font: $typography-regular-small-body;
   margin: $layout-margin-none;
 }
@@ -145,7 +146,7 @@
 > .bcds-footer--logo
 > p
 > a:hover {
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .bcds-footer
@@ -176,6 +177,7 @@
 > .bcds-footer--links-title {
   display: block;
   font: $typography-bold-small-body;
+  color: $typography-color-primary;
   margin-bottom: $layout-padding-medium;
   text-transform: uppercase;
 }
@@ -228,7 +230,7 @@
 > li
 > a {
   color: $typography-color-primary;
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 

--- a/frontend/_extensions/bcds/bcds-footer.scss
+++ b/frontend/_extensions/bcds/bcds-footer.scss
@@ -6,7 +6,6 @@
 @import "variables.scss";
 
 .bcds-footer {
-  margin-top: 10rem;
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/frontend/_extensions/bcds/bcds-footer.scss
+++ b/frontend/_extensions/bcds/bcds-footer.scss
@@ -147,6 +147,7 @@
 > p
 > a:hover {
   text-decoration: underline;
+  color: $theme-gray-90;
 }
 
 .bcds-footer
@@ -271,7 +272,7 @@
 
 p.bcds-footer--copyright {
   color: $typography-color-secondary;
-  font: $typography-regular-body;
+  font: $typography-regular-small-body;
   margin: $layout-margin-none;
 }
 

--- a/frontend/_extensions/bcds/bcds-footer.scss
+++ b/frontend/_extensions/bcds/bcds-footer.scss
@@ -147,7 +147,7 @@
 > p
 > a:hover {
   text-decoration: underline;
-  color: $theme-gray-90;
+  color: $theme-gray-80;
 }
 
 .bcds-footer
@@ -260,6 +260,7 @@
 > li
 > a:hover {
   text-decoration: underline;
+  color: $theme-gray-80;
 }
 
 .bcds-footer > .bcds-footer--container > .bcds-footer--container-content > hr {


### PR DESCRIPTION
Update:
- the footer year to say 2026 
- small style tweaks to make the footer align with gov.bc.ca and remove all the margin whitespace
- update border radius for accordians to match