### PR TITLE
Replace incorrect air quality link

### DIFF
--- a/archive/2025-10-30_Issue_PM25_Golden.md
+++ b/archive/2025-10-30_Issue_PM25_Golden.md
@@ -79,7 +79,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on October 31, 2025 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 # Actions you can take
 

--- a/frontend/warnings/2025-10-30_Issue_PM25_Golden.html
+++ b/frontend/warnings/2025-10-30_Issue_PM25_Golden.html
@@ -284,7 +284,7 @@ To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0
 <p>Open burning restrictions are now in effect within 50 km of the Golden and District hospital until November 1, 2025 12:00 PM local time. No new fires may be initiated, and no additional material may be added to existing fires. For more information on burning restrictions, refer to the Mandatory Emission Reduction Actions section below.</p>
 <p>Visit the provincial <a href="https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality">air quality data webpage</a> for real-time observations.</p>
 <p>Current conditions are expected to persist until weather conditions change and/or local emissions are reduced.</p>
-<p>The next update will be on October 31, 2025 and posted to the province’s <a href="https://www.gov.bc.ca/airquality">Air Quality Warnings webpage</a>.</p>
+<p>The next update will be on October 31, 2025 and posted to the province’s <a href="https://aqwarnings.gov.bc.ca/">Air Quality Warnings webpage</a>.</p>
 <section id="actions-you-can-take" class="level1">
 <h1>Actions you can take</h1>
 <p>As air contaminant levels increase, health risks increase. Consider reducing or rescheduling outdoor sports, activities and events.</p>

--- a/frontend/warnings/2026-01-16_Valemount_issue_pm25.md
+++ b/frontend/warnings/2026-01-16_Valemount_issue_pm25.md
@@ -66,7 +66,7 @@ conditions will likely continue until weather changes or local emissions
 decrease.
 
 The next update will be on January 17, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-16_Vanderhoof_issue_pm25.md
+++ b/frontend/warnings/2026-01-16_Vanderhoof_issue_pm25.md
@@ -64,7 +64,7 @@ Current conditions will likely continue until weather changes or local
 emissions decrease.
 
 The next update will be on January 17, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-17_Vanderhoof_continue_pm25.md
+++ b/frontend/warnings/2026-01-17_Vanderhoof_continue_pm25.md
@@ -65,7 +65,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 18, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-18_Prince_George_issue_pm25.md
+++ b/frontend/warnings/2026-01-18_Prince_George_issue_pm25.md
@@ -64,7 +64,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 19, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-18_Vanderhoof_continue_pm25.md
+++ b/frontend/warnings/2026-01-18_Vanderhoof_continue_pm25.md
@@ -65,7 +65,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 19, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-19_Prince_George_continue_pm25.md
+++ b/frontend/warnings/2026-01-19_Prince_George_continue_pm25.md
@@ -65,7 +65,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 20, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-19_Quesnel_issue_pm25.md
+++ b/frontend/warnings/2026-01-19_Quesnel_issue_pm25.md
@@ -64,7 +64,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 20, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-19_Vanderhoof_continue_pm25.md
+++ b/frontend/warnings/2026-01-19_Vanderhoof_continue_pm25.md
@@ -65,7 +65,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 20, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-20_Prince_George_continue_pm25.md
+++ b/frontend/warnings/2026-01-20_Prince_George_continue_pm25.md
@@ -70,7 +70,7 @@ levels have been rising in recent hours. These conditions are expected
 to persist until the weather changes or local emissions decrease.
 
 The next update will be on January 21, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-20_Smithers_issue_pm10.md
+++ b/frontend/warnings/2026-01-20_Smithers_issue_pm10.md
@@ -64,7 +64,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 21, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-21_Smithers_continue_pm10.md
+++ b/frontend/warnings/2026-01-21_Smithers_continue_pm10.md
@@ -65,7 +65,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 22, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-23_Prince_George_issue_pm25.md
+++ b/frontend/warnings/2026-01-23_Prince_George_issue_pm25.md
@@ -64,7 +64,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 24, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-23_Valemount_issue_pm25.md
+++ b/frontend/warnings/2026-01-23_Valemount_issue_pm25.md
@@ -64,7 +64,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 24, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-24_Prince_George_continue_pm25.md
+++ b/frontend/warnings/2026-01-24_Prince_George_continue_pm25.md
@@ -65,7 +65,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 25, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-24_Valemount_continue_pm25.md
+++ b/frontend/warnings/2026-01-24_Valemount_continue_pm25.md
@@ -65,7 +65,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 25, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-24_Vanderhoof_issue_pm25.md
+++ b/frontend/warnings/2026-01-24_Vanderhoof_issue_pm25.md
@@ -64,7 +64,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 25, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-25_Prince_George_continue_pm25.md
+++ b/frontend/warnings/2026-01-25_Prince_George_continue_pm25.md
@@ -65,7 +65,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 26, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-25_Valemount_continue_pm25.md
+++ b/frontend/warnings/2026-01-25_Valemount_continue_pm25.md
@@ -65,7 +65,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on January 26, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-26_Vanderhoof_issue_pm25.md
+++ b/frontend/warnings/2026-01-26_Vanderhoof_issue_pm25.md
@@ -64,7 +64,7 @@ Fine particulate matter concentrations have remained elevated over the
 past 24-hours despite local snowfall.
 
 The next update will be on January 27, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-01-27_Vanderhoof_continue_pm25.md
+++ b/frontend/warnings/2026-01-27_Vanderhoof_continue_pm25.md
@@ -69,7 +69,7 @@ warning. Current conditions are expected to persist until weather
 conditions change and/or local emissions are reduced.
 
 The next update will be on January 28, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-02-12_Golden_issue_pm10.md
+++ b/frontend/warnings/2026-02-12_Golden_issue_pm10.md
@@ -65,7 +65,7 @@ change and/or local emissions are reduced.
 
 The next update will be on February 13, 2026 and posted to the
 province's [Air Quality Warnings
-webpage](https://www.gov.bc.ca/airquality).
+webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-02-13_Golden_continue_pm10.md
+++ b/frontend/warnings/2026-02-13_Golden_continue_pm10.md
@@ -66,7 +66,7 @@ change and/or local emissions are reduced.
 
 The next update will be on February 14, 2026 and posted to the
 province's [Air Quality Warnings
-webpage](https://www.gov.bc.ca/airquality).
+webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-03-02_Golden_issue_pm10.md
+++ b/frontend/warnings/2026-03-02_Golden_issue_pm10.md
@@ -62,7 +62,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on March 03, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-03-03_Golden_continue_pm10.md
+++ b/frontend/warnings/2026-03-03_Golden_continue_pm10.md
@@ -63,7 +63,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on March 04, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-03-03_Vernon_issue_pm10.md
+++ b/frontend/warnings/2026-03-03_Vernon_issue_pm10.md
@@ -62,7 +62,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on March 04, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-03-06_Golden_issue_pm10.md
+++ b/frontend/warnings/2026-03-06_Golden_issue_pm10.md
@@ -62,7 +62,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on March 07, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-03-13_Smithers_issue_pm10.md
+++ b/frontend/warnings/2026-03-13_Smithers_issue_pm10.md
@@ -62,7 +62,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on March 14, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-03-23_Golden_issue_pm10.md
+++ b/frontend/warnings/2026-03-23_Golden_issue_pm10.md
@@ -62,7 +62,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on March 24, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-03-24_Golden_continue_pm10.md
+++ b/frontend/warnings/2026-03-24_Golden_continue_pm10.md
@@ -63,7 +63,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on March 25, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-03-27_Golden_issue_pm10.md
+++ b/frontend/warnings/2026-03-27_Golden_issue_pm10.md
@@ -62,7 +62,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on March 28, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-03-28_Golden_continue_pm10.md
+++ b/frontend/warnings/2026-03-28_Golden_continue_pm10.md
@@ -63,7 +63,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on March 29, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-04-01_Golden_issue_pm10.md
+++ b/frontend/warnings/2026-04-01_Golden_issue_pm10.md
@@ -62,7 +62,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on April 02, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-04-10_Williams_Lake_issue_pm10.md
+++ b/frontend/warnings/2026-04-10_Williams_Lake_issue_pm10.md
@@ -62,7 +62,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on April 11, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-05-04_Quesnel_issue_pm10.md
+++ b/frontend/warnings/2026-05-04_Quesnel_issue_pm10.md
@@ -81,7 +81,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on May 05, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-05-06_Quesnel_issue_pm10.md
+++ b/frontend/warnings/2026-05-06_Quesnel_issue_pm10.md
@@ -81,7 +81,7 @@ Current conditions are expected to persist until weather conditions
 change and/or local emissions are reduced.
 
 The next update will be on May 07, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)

--- a/frontend/warnings/2026-05-08_Quesnel_issue_pm10.md
+++ b/frontend/warnings/2026-05-08_Quesnel_issue_pm10.md
@@ -81,7 +81,7 @@ Conditions may improve later in the day as meteorological conditions
 change.
 
 The next update will be on May 09, 2026 and posted to the province's
-[Air Quality Warnings webpage](https://www.gov.bc.ca/airquality).
+[Air Quality Warnings webpage](https://aqwarnings.gov.bc.ca/).
 
 Visit the provincial [air quality data
 webpage](https://www2.gov.bc.ca/gov/content/environment/air-land-water/air/air-quality)


### PR DESCRIPTION
Looks like 36 (35 in 2026, 1 in 2025)) previous warnings had the incorrect link. I've updated and also updated the archived copy of the one warning issued in 2025.

Fixes website side of: https://github.com/bcgov/aqwarnings_shiny/issues/115